### PR TITLE
Properly implement class inheritance for class MMcP with McFileDownloader

### DIFF
--- a/src/fileDownloader.py
+++ b/src/fileDownloader.py
@@ -1,18 +1,19 @@
 import shutil
 import requests
-from mmcp import *
 from concurrent.futures import ThreadPoolExecutor
 
 class McFileDownloader:
+     manifest = ""
+
      def fetchVersionManifest(self):
         # Fetch the version manifest from Mojang's servers
         manifest_url = "https://launchermeta.mojang.com/mc/game/version_manifest_v2.json"
         response = requests.get(manifest_url)
         manifest = response.json()
-        return manifest
+        self.manifest = manifest
      
         # Fetch the Minecraft version manifest
-        manifest = self.fetchVersionManifest()
+        # manifest = self.fetchVersionManifest()
 
      def getVersionInfo(self, version_id, manifest):
         # Get the specific version information from the manifest

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,7 @@ def main():
     if os.name == "nt": # Windows
         launcherDir = "C:\\XboxGames\\Minecraft Launcher\\Content\\Minecraft.exe"
     elif os.name == "posix": # Linux
-        launcherDir = "minecraft-launcher"
+        launcherDir = "/sbin/minecraft-launcher"
     elif os.name == "darwin": #MacOS
         launcherDir = "/Applications/Minecraft.app"
     else:
@@ -29,4 +29,4 @@ def main():
 
 if __name__ == "__main__":
     main()
-    input()
+    #input()

--- a/src/mmcp.py
+++ b/src/mmcp.py
@@ -20,6 +20,11 @@ class MMcP(McFileDownloader):
             self.defaultDir.mkdir()
             print(f"Default instance created at: {self.defaultDir}")
 
+        else:
+            for i in Path(self.defaultDir).iterdir():
+                self.instances.append(GameInstance(i.name, i))
+                print("Imported instance:\n{} | {}".format(i.name,i))
+
     def createInstance(self, name):
 
         # Ask user what type of versions they want to see
@@ -102,5 +107,18 @@ class MMcP(McFileDownloader):
             print(f"No instance directory found for: {name}")
 
     def startMinecraft(self):
+        i = 0
+        print("Select instance to run:")
+        for j in self.instances:
+            i += 1
+            print("[{}]: {}".format(i, j.instanceName))
+        
+        try:
+            selected = int(input()) - 1
+        except:
+            print("Input is not a number. Defaulting to first option.")
+            selected = 0
+        
         print("Starting Minecraft Launcher, please wait.....")
-        subprocess.Popen(self.minecraftLauncher)
+        formattedString = "--workDir=" + str(self.instances[selected].instanceDir.absolute())
+        subprocess.Popen([self.minecraftLauncher, formattedString])

--- a/src/mmcp.py
+++ b/src/mmcp.py
@@ -9,7 +9,7 @@ class GameInstance:
         self.instanceName = instanceName
         self.instanceDir = instanceDir
 
-class MMcP:
+class MMcP(McFileDownloader):
     def __init__(self, minecraftLauncher):
         self.minecraftLauncher = minecraftLauncher
         self.instances = []
@@ -42,7 +42,7 @@ class MMcP:
             version_types = ["release"]
 
         # List available versions and prompt user to choose
-        filtered_versions = [v for v in manifest['versions'] if v['type'] in version_types]
+        filtered_versions = [v for v in super().manifest['versions'] if v['type'] in version_types]
         print("\nAvailable Minecraft Versions:")
         for version in filtered_versions:
             print(f"- {version['id']} ({version['type']})")
@@ -50,7 +50,7 @@ class MMcP:
         version_id = input("Enter the Minecraft version: ")
 
         # Fetch version info for the selected version
-        version_info = self.getVersionInfo(version_id, manifest)
+        version_info = self.getVersionInfo(version_id, super().manifest)
         if not version_info:
             print(f"Version {version_id} not found!")
             return


### PR DESCRIPTION
The `MMcP` class now properly inherits `McFileDownloader` as its superclass, allowing access to its properties and methods (currently only `manifest` is used).

Apart from that, I have also refactored `MMcP.startMinecraft()` function as well as `__init__` so that any existing instances will be imported and is added into `self.instances`. Now, this method now shows a menu of which the user then chose the desired instance to launch.

In the future, this method should be automatic, as in the current active instance will be the one this method will start into. For now, having it set manually should suffice. 