### PR TITLE
Added: MavenFetcher helper class and FabricMeta meta class.

### DIFF
--- a/src/resourceFetchers/fabric.py
+++ b/src/resourceFetchers/fabric.py
@@ -1,0 +1,63 @@
+import shutil
+import requests
+import json
+from resourceFetchers.mavenFetcher import MavenFetcher
+from concurrent.futures import ThreadPoolExecutor
+
+class FabricMeta:
+    __base_manifest_url = "https://meta.fabricmc.net/v2/versions"
+    __manifest_url = __base_manifest_url + "/game"
+
+    # Get the required data first.
+    manifest = requests.get(__manifest_url)
+    if (manifest.ok and manifest.status_code == 200):
+        manifest = manifest.json()
+
+    def __init__(self, compatible_version):
+        self.compatible_version = compatible_version
+
+    def fetch(self):
+        newLink = self.__base_manifest_url + "/loader"
+        data = "No resources available" # Will be modified if succeeded
+        try:
+            for i in self.manifest:
+                if(i["version"] == self.compatible_version):
+                    newResponse = requests.get(newLink + "/" + i["version"])
+                    newResponse.raise_for_status()
+
+                    # Gotta say, not a big fan of not having an equivalent of
+                    # Javascript's Array.forEach() function in Python, so we got
+                    # A bunch of for-in's just to get something similar working.
+                    # This may be redundant, but we are defaulting to using the one
+                    # that is marked as stable for convenience
+                    for i in newResponse.json():
+                        if i["loader"]["stable"]:
+                            data = i
+                            break
+                    
+                    print(f"Selected loader version {data["loader"]["version"]} as the best version.")
+
+                    # While the idea is to programatically get the link to the main resource,
+                    # I decided I've wasted enough time doing all that, so here it is.
+                    mm = MavenFetcher("https://maven.fabricmc.net/")
+                    mm.fromString(data["loader"]["maven"])
+                    
+                    # Yo dawg, I heard you guys love some loops.
+                    # So here's something for you:
+                    # 
+                    # Loop Hell, trademark.
+                    for i in data["launcherMeta"]["libraries"]:
+                        for j in data["launcherMeta"]["libraries"][i]:
+                            try:
+                                mm = MavenFetcher(j["url"])
+                                mm.fromString(j["name"])
+                                print(f"fetched {j["name"]} from {j["url"]}")
+                            except Exception as e:
+                                print(f"Something happened, and here's the error:\n{e}")
+                                break
+
+                    break
+        except Exception as e:
+            print("Error occured while parsing data:\n",e)
+
+        return data

--- a/src/resourceFetchers/mavenFetcher.py
+++ b/src/resourceFetchers/mavenFetcher.py
@@ -1,0 +1,50 @@
+import requests
+
+class MavenFetcher:
+    def __init__(self, baseUrl) -> None:
+        self.targetUrl = baseUrl
+
+    def fromString(self, inputString):
+        inputString = inputString.split(":")
+
+        # Handles forward slash insertion between
+        # target URL and string when there's none.
+        if inputString[0][0] != "/" and self.targetUrl[-1] != "/":
+            inputString[0].insert(0, "/")
+
+        self.__g = inputString[0]
+        self.__a = inputString[1]
+        self.__v = inputString[2]
+        return self
+
+    def fromGav(self, groupID, artifactID, artifactVersion):
+        self.__g = groupID
+        self.__a = artifactID
+        self.__v = artifactVersion
+        return self
+
+    def getResource(self) -> None:
+        # Making sure there's no nonsense.
+        if self.__g == "" or self.__a == "" or self.__v == "":
+            raise Exception("Incomplete constructor. Please call the method fromString() or fromGav() before calling this method.")
+
+        # Assembles everything to become a downloadable URL.
+        self.__g = self.__g.replace(".", "/")
+        self.__n = self.__a + "-" + self.__v + ".jar"
+        self.__s = self.__g + "/" + self.__a + "/" + self.__v + "/" + self.__n
+
+        self.__u = self.targetUrl + self.__s
+
+        # Performing test to make sure we are looking at a JAR file.
+        header = requests.head(self.__u, allow_redirects=True)
+        header.raise_for_status()
+        header = header.headers.get('content-type')
+        if "application/java-archive" in header.lower():
+            try:
+                response = requests.get(self.__u, allow_redirects=True)
+                response.raise_for_status()
+                open(self.__n, "wb").write(response.content)
+            except Exception as e:
+                raise print(f"An error occured while obtaining the following resource:\n{e}")
+        else:
+            raise Exception("Failure in obtaining JAR. The requested link does not point to a JAR file.")


### PR DESCRIPTION
`MavenFetcher` from `resourceFetchers/mavenFetcher.py` is a new helper class to manage resources that are hosted via Maven. Current implementation is naive and contains a few downsides, some of them being that it only concerns downloading `.jar` files as that is the only objective. Another one is that, when issuing the `getResource()` method, it will immediately download the resource into the root working folder. Future plans for the `getResource()` method are creating the directory structure before downloading and storing resources to their respective location. All properties used in this helper class are private as of now, but as future improvements made, properties will be made public wherever appropriate.

Another addition is the new `FabricMeta` meta class in `resourceFetchers/fabric.py`. This meta class will be used to add features regarding resource downloading of the Fabric mod loader. In its current state, it works as in being able to point to the correct resource and downloads them with `MavenFetcher`, but it is still far from being fully usable. Once the improvements in `MavenFetcher` is completed, `FabricMeta` can then be improved and finalized.